### PR TITLE
Remove Win32 as a platform for UE5

### DIFF
--- a/MIVIBridge.uplugin
+++ b/MIVIBridge.uplugin
@@ -21,8 +21,7 @@
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
 			"WhitelistPlatforms": [
-				"Win64",
-				"Win32"
+				"Win64"
 			]
 		}
 	],


### PR DESCRIPTION
Win32 was deprecated in 4.27 and removed in 5.